### PR TITLE
Polish bindings list toggles and deletion flow

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -21,14 +21,20 @@
     "unitSingle": "key",
     "unitPlural": "keys",
     "decrementLabel": "Lower semitone",
-    "incrementLabel": "Raise semitone"
+    "incrementLabel": "Raise semitone",
+    "valueButtonLabel": "Edit transpose value",
+    "valueInputLabel": "Transpose semitone offset",
+    "invalidValue": "Enter a value between -12 and +12."
   },
   "speed": {
     "title": "Speed",
     "label": "Percent",
     "reset": "Reset",
     "decrementLabel": "Slow down",
-    "incrementLabel": "Speed up"
+    "incrementLabel": "Speed up",
+    "valueButtonLabel": "Edit speed value",
+    "valueInputLabel": "Playback speed percentage",
+    "invalidValue": "Enter a value between 50 and 200."
   },
   "twitch": {
     "statusDisconnected": "Disconnected",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -75,6 +75,8 @@
     "empty": "No bindings yet.",
     "toggleLabel": "Enabled",
     "delete": "Delete",
+    "deleteConfirm": "Confirm?",
+    "toggleAria": "Enable or disable {label}",
     "unsavedConfirm": "Leave without saving?",
     "unsavedConfirmLeave": "Leave",
     "unsavedConfirmCancel": "Cancel",

--- a/src/locales/pseudo.json
+++ b/src/locales/pseudo.json
@@ -75,6 +75,8 @@
     "empty": "Ňō ƅīņđīņĝś ẏēŧ.",
     "toggleLabel": "Ĕņàƅļēđ",
     "delete": "Đēļēŧē",
+    "deleteConfirm": "Ćōņƒīŕṁ?",
+    "toggleAria": "Ĕņàƅļē ōŗ đīśàƅļē {label}",
     "unsavedConfirm": "Ľēàṽē ŵīŧĥōŭŧ śàṽīņĝ?",
     "unsavedConfirmLeave": "Ľēàṽē",
     "unsavedConfirmCancel": "Ćàņćēļ",

--- a/src/locales/pseudo.json
+++ b/src/locales/pseudo.json
@@ -21,14 +21,20 @@
     "unitSingle": "ķēŷ",
     "unitPlural": "ķēŷś",
     "decrementLabel": "Ļōŵēŕ śēmīŧōņē",
-    "incrementLabel": "Řàīśē śēmīŧōņē"
+    "incrementLabel": "Řàīśē śēmīŧōņē",
+    "valueButtonLabel": "Ĕđīŧ ŧŕàņśƥōśē ṽàļŭē",
+    "valueInputLabel": "Ŧŕàņśƥōśē śēmīŧōņē ōƒƒśēŧ",
+    "invalidValue": "Ĕņŧēŕ à ṽàļŭē ƀēŧŵēēņ −12 àņđ +12."
   },
   "speed": {
     "title": "Ŝƥēēđ",
     "label": "Ƥēŕćēņŧ",
     "reset": "Řēśēŧ",
     "decrementLabel": "Ŝļōŵ đōŵņ",
-    "incrementLabel": "Ŝƥēēđ ŭƥ"
+    "incrementLabel": "Ŝƥēēđ ŭƥ",
+    "valueButtonLabel": "Ĕđīŧ śƥēēđ ṽàļŭē",
+    "valueInputLabel": "Ƥļàŷƀàćķ śƥēēđ ƥēŗćēņŧàĝē",
+    "invalidValue": "Ĕņŧēŕ à ṽàļŭē ƀēŧŵēēņ 50 àņđ 200."
   },
   "twitch": {
     "statusDisconnected": "Đīśćōņņēćŧēđ",

--- a/src/popup/styles/main.css
+++ b/src/popup/styles/main.css
@@ -105,6 +105,7 @@ textarea:focus-visible {
 
 input[type='range'] {
   width: 100%;
+  flex: 1 1 auto;
 }
 
 .control-block {
@@ -139,15 +140,52 @@ input[type='range'] {
 .control-block__value {
   font-weight: 600;
   color: #f5f5f7;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 64px;
 }
 
 .control-block__reset {
   padding-inline: 10px;
 }
 
+.control-block__value-button {
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  padding: 4px 10px;
+  cursor: text;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.control-block__value-button:hover,
+.control-block__value-button:focus-visible {
+  border-color: var(--panel-border);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.control-block__value-input {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  padding: 4px 10px;
+  text-align: center;
+  color: inherit;
+  width: 80px;
+}
+
+.control-block__value-input::-webkit-inner-spin-button,
+.control-block__value-input::-webkit-outer-spin-button {
+  margin: 0;
+}
+
 .stepper {
   width: 32px;
   height: 32px;
+  flex: 0 0 32px;
+  min-width: 32px;
+  min-height: 32px;
   border-radius: 50%;
   border: 1px solid var(--panel-border);
   background: rgba(255, 255, 255, 0.08);
@@ -270,12 +308,14 @@ input[type='range'] {
 .twitch-card__logo {
   width: 36px;
   height: 36px;
+  flex: 0 0 36px;
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
   border: 2px solid var(--panel-border);
   background: rgba(145, 70, 255, 0.15);
+  overflow: hidden;
 }
 
 .twitch-card__logo img {
@@ -400,12 +440,20 @@ input[type='range'] {
 
 .field select {
   appearance: none;
+  background-color: rgba(18, 18, 24, 0.9);
+  border-color: rgba(255, 255, 255, 0.2);
+  border-radius: 10px;
   background-image: linear-gradient(45deg, transparent 50%, rgba(255, 255, 255, 0.4) 50%),
     linear-gradient(135deg, rgba(255, 255, 255, 0.4) 50%, transparent 50%);
   background-position: calc(100% - 12px) calc(50% - 3px), calc(100% - 7px) calc(50% - 3px);
   background-size: 5px 5px, 5px 5px;
   background-repeat: no-repeat;
   padding-right: 24px;
+}
+
+.field select option {
+  background-color: #1e1e26;
+  color: #f5f5f7;
 }
 
 .field__label {

--- a/src/popup/styles/main.css
+++ b/src/popup/styles/main.css
@@ -44,6 +44,18 @@ textarea:focus-visible {
   outline-offset: 2px;
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 #app {
   padding: 16px;
   box-sizing: border-box;
@@ -535,24 +547,62 @@ input[type='range'] {
 }
 
 .binding-row {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
   padding: 12px;
   border-radius: var(--border-radius);
   border: 1px solid var(--panel-border);
   margin-bottom: 8px;
   gap: 12px;
+  transition: background-color 0.2s ease;
 }
 
-.binding-row__actions {
+.binding-row--hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.binding-row__toggle {
   display: flex;
   align-items: center;
-  gap: 8px;
+  justify-content: center;
+}
+
+.binding-row__main {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  background: transparent;
+  border: none;
+  padding: 8px 12px;
+  border-radius: var(--border-radius);
+  text-align: left;
+  cursor: pointer;
+}
+
+.binding-row__label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .binding-row__chevron {
   font-size: 18px;
+}
+
+.binding-row__delete {
+  white-space: nowrap;
+}
+
+.binding-row__delete--confirm {
+  color: var(--status-disconnected);
+}
+
+.binding-row__delete--confirm:hover {
+  background: rgba(248, 81, 73, 0.18);
 }
 
 .empty {


### PR DESCRIPTION
## Summary
- separate binding enable toggles from the navigation button so they no longer open the editor
- add a double-confirm delete interaction with timeout and outside-click cancellation plus matching styling tweaks
- extend locale strings and utility styles to support the new aria labels and confirmation UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e31ad433e4832c8d2e3f6ab1d667f1