### PR TITLE
Implement Phase 2 Twitch auth and EventSub wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
-# Twitch AudioFX Extension (Phase 1)
+# Twitch AudioFX Extension (Phase 2)
 
-This repository contains the Phase 1 scaffold for the Twitch AudioFX Chrome extension. The goal for this milestone is to deliver the full popup UI, persistent state management, and typed messaging stubs without integrating Twitch APIs or audio processing yet.
+This repository delivers the Phase 2 milestone for the Twitch AudioFX Chrome extension. The popup and bindings UX from Phase 1 r
+emain unchanged, but the extension now authenticates with Twitch and listens for real EventSub notifications from the backgroun
+d service worker.
 
 ## Getting Started
 
 ```bash
 npm install
-npm run build
+TWITCH_CLIENT_ID=your_client_id npm run build
 ```
 
-The build script bundles the background service worker, popup, and content script into `dist/` and copies the MV3 manifest plus locale files.
+The build script bundles the background service worker, popup, and content script into `dist/` and copies the MV3 manifest plus
+locale files.
 
 To load the extension in Chrome:
 
@@ -17,18 +20,39 @@ To load the extension in Chrome:
 2. Open `chrome://extensions` and enable **Developer mode**.
 3. Choose **Load unpacked** and select the generated `dist` directory.
 
-## Features Implemented in Phase 1
+### Twitch OAuth Setup
 
-- Manifest V3 scaffold targeting Chrome 116+ with `identity`, `storage`, `scripting`, and `activeTab` permissions.
-- Runtime language switching backed by JSON locale files discovered automatically at build time.
-- Popup UI with:
-  - Transpose and speed controls (UI state only) including sliders, +/- buttons, and reset actions.
-  - Twitch status row with stubbed Connect/Disconnect button, capture toggle, and persisted state.
-  - Test Events form gated behind a logged-in flag that logs simulated payloads and shows toasts.
-  - Bindings list and add/edit flows with persistence, validation, unsaved-change confirmation, and delete/toggle interactions.
-  - Collapsible diagnostics panel exposing stored state.
-- Background and content script stubs with typed messaging channels prepared for later Twitch/EventSub and audio routing logic.
-- Persistent popup state stored via `chrome.storage.local` through the background service worker.
-- Simple toast and confirmation utilities for user feedback.
+1. Call `chrome.identity.getRedirectURL('twitch')` in the extension console to obtain the redirect URI. Unless you override the p
+ath it will be `https://<EXTENSION_ID>.chromiumapp.org/twitch`.
+2. Configure your Twitch developer application with that redirect URI and note the client ID.
+3. Provide the client ID at build time via the `TWITCH_CLIENT_ID` environment variable. Optionally set `TWITCH_REDIRECT_PATH` to
+ adjust the redirect suffix (defaults to `twitch`).
+4. Grant the application the following scopes, which the extension requires when authenticating:
+   - `channel:read:redemptions`
+   - `bits:read`
+   - `channel:read:subscriptions`
 
-Future phases will add real Twitch authentication, EventSub WebSocket handling, audio effect engines, bindings execution, and packaged release assets.
+## Features Implemented in Phase 2
+
+- Manifest V3 configuration targeting Chrome 116+ with `identity`, `storage`, `scripting`, `activeTab`, and host permissions for
+ `https://id.twitch.tv/*` and `https://api.twitch.tv/*`.
+- OAuth connect/reconnect/disconnect flows that persist the broadcaster's access token, scopes, display name, and user ID in `chr
+ome.storage.local`.
+- Background EventSub WebSocket client that automatically creates WebSocket-transport subscriptions for channel points redemptio
+ns, cheers, subscriptions, and follows. Keepalive tracking, exponential reconnect backoff, subscription cleanup, and Helix rate-
+limit handling are built in.
+- The capture toggle now gates live EventSub notifications, while the Test Events form sends structured payloads through the sam
+e routing path for quick verification.
+- The diagnostics panel reports WebSocket connectivity, current session ID, active subscription count, last keepalive time, last 
+notification type/time, and the most recent error.
+- Popup toasts surface authentication success/failure, missing scope requirements, capture-disabled warnings, and test-event sta
+tus updates based on background action responses.
+
+## Debugging Tips
+
+- Open `chrome://extensions`, locate the loaded extension, and use the **Service worker** → **Inspect views** link to watch cons
+ole logs and network activity.
+- From the same page, the **View service worker** link shows lifecycle state and lets you manually restart the worker while testi
+ng reconnect scenarios.
+- Authentication or subscription issues will be logged in the service worker console; watch for `401` (token expired) or `429` (r
+ate limit) responses when exercising the Twitch APIs.

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -30,6 +30,10 @@ async function bundle() {
     logLevel: 'info',
     loader: {
       '.json': 'json'
+    },
+    define: {
+      'process.env.TWITCH_CLIENT_ID': JSON.stringify(process.env.TWITCH_CLIENT_ID ?? ''),
+      'process.env.TWITCH_REDIRECT_PATH': JSON.stringify(process.env.TWITCH_REDIRECT_PATH ?? 'twitch')
     }
   });
 }

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -7,23 +7,796 @@ import {
 import {
   createDefaultPopupState,
   POPUP_STATE_STORAGE_KEY,
-  type PopupPersistentState
+  type PopupPersistentState,
+  type BindingEventType,
+  type SubTier,
+  type TestEventType
 } from '../shared/state';
-import { loadFromStorage, saveToStorage } from '../shared/storage';
+import { loadFromStorage, removeFromStorage, saveToStorage } from '../shared/storage';
+import {
+  TWITCH_AUTH_STORAGE_KEY,
+  TWITCH_CLIENT_ID,
+  TWITCH_EVENTSUB_WS,
+  TWITCH_HELIX_BASE,
+  TWITCH_REDIRECT_PATH,
+  TWITCH_REQUIRED_SCOPES,
+  createEmptyDiagnostics,
+  getRequiredEventSubDefinitions,
+  scopesMissing,
+  type EventSubSubscriptionDefinition,
+  type TwitchAuthData,
+  type TwitchDiagnosticsSnapshot
+} from '../shared/twitch';
+
+const AUTH_EXPIRY_PADDING_MS = 60_000;
+const INITIAL_BACKOFF_MS = 1_000;
+const MAX_BACKOFF_MS = 60_000;
+
+type TimeoutHandle = ReturnType<typeof setTimeout>;
+
+type RoutedEventSource = 'eventsub' | 'test';
+
+interface RoutedEvent {
+  source: RoutedEventSource;
+  subscriptionType: string;
+  bindingType: BindingEventType;
+  receivedAt: number;
+  payload: unknown;
+}
+
+interface HelixSubscription {
+  id: string;
+  status: string;
+  type: string;
+  version: string;
+  condition: Record<string, string>;
+  transport: {
+    method: string;
+    session_id?: string;
+  };
+}
+
+class MissingClientIdError extends Error {
+  constructor() {
+    super('Missing Twitch client ID');
+    this.name = 'MissingClientIdError';
+  }
+}
+
+class MissingScopesError extends Error {
+  constructor(public readonly missing: string[]) {
+    super('Missing required Twitch scopes');
+    this.name = 'MissingScopesError';
+  }
+}
+
+class AuthCancelledError extends Error {
+  constructor(message = 'Authentication cancelled') {
+    super(message);
+    this.name = 'AuthCancelledError';
+  }
+}
 
 let cachedState: PopupPersistentState = createDefaultPopupState();
+let twitchAuth: TwitchAuthData | null = null;
+let diagnostics: TwitchDiagnosticsSnapshot = createEmptyDiagnostics();
 
+let eventSubSocket: WebSocket | null = null;
+let eventSubSessionId: string | null = null;
+let eventSubReconnectTimer: TimeoutHandle | null = null;
+let keepaliveTimer: TimeoutHandle | null = null;
+let keepaliveTimeoutMs = 0;
+let reconnectBackoffMs = INITIAL_BACKOFF_MS;
 async function init(): Promise<void> {
   cachedState = await loadFromStorage(POPUP_STATE_STORAGE_KEY, createDefaultPopupState());
+  twitchAuth = await loadFromStorage(TWITCH_AUTH_STORAGE_KEY, null);
+  await syncStateWithAuth({ persist: false, broadcast: false, keepDisplayName: true });
+
+  if (twitchAuth && isAuthUsable(twitchAuth)) {
+    try {
+      await refreshStoredProfile();
+      await startEventSub();
+    } catch (error) {
+      console.warn('[background] Failed to resume Twitch session', error);
+      await handleAuthFailure(error);
+    }
+  } else if (twitchAuth) {
+    await handleExpiredToken();
+  }
 }
 
 void init();
 
-function respondToPopup(
-  sendResponse: (response?: BackgroundToPopupMessage) => void,
-  message: BackgroundToPopupMessage
-): void {
+function broadcastState(): void {
+  try {
+    chrome.runtime.sendMessage({ type: 'BACKGROUND_STATE', state: cachedState }, () => {
+      void chrome.runtime.lastError;
+    });
+  } catch (error) {
+    console.debug('[background] Failed to broadcast state', error);
+  }
+}
+
+function pushDiagnostics(): void {
+  try {
+    chrome.runtime.sendMessage({ type: 'BACKGROUND_DIAGNOSTICS', diagnostics }, () => {
+      void chrome.runtime.lastError;
+    });
+  } catch (error) {
+    console.debug('[background] Failed to push diagnostics', error);
+  }
+}
+
+async function persistCachedState(): Promise<void> {
+  await saveToStorage(POPUP_STATE_STORAGE_KEY, cachedState);
+}
+
+async function updateCachedState(
+  partial: Partial<PopupPersistentState>,
+  options: { persist?: boolean; broadcast?: boolean } = {}
+): Promise<void> {
+  const { persist = true, broadcast = true } = options;
+  cachedState = { ...cachedState, ...partial };
+  if (persist) {
+    await persistCachedState();
+  }
+  if (broadcast) {
+    broadcastState();
+  }
+}
+
+async function syncStateWithAuth(options: {
+  persist?: boolean;
+  broadcast?: boolean;
+  keepDisplayName?: boolean;
+} = {}): Promise<void> {
+  const { persist = true, broadcast = true, keepDisplayName = true } = options;
+  const loggedIn = twitchAuth !== null && isAuthUsable(twitchAuth);
+  const displayName = twitchAuth?.displayName ?? (keepDisplayName ? cachedState.twitchDisplayName : null);
+  await updateCachedState(
+    {
+      loggedIn,
+      twitchDisplayName: displayName ?? null
+    },
+    { persist, broadcast }
+  );
+}
+
+function updateDiagnostics(partial: Partial<TwitchDiagnosticsSnapshot>): void {
+  diagnostics = { ...diagnostics, ...partial };
+  pushDiagnostics();
+}
+
+function isAuthUsable(auth: TwitchAuthData): boolean {
+  return auth.expiresAt - AUTH_EXPIRY_PADDING_MS > Date.now();
+}
+
+async function setAuthData(
+  next: TwitchAuthData | null,
+  options: { keepDisplayName?: boolean; broadcast?: boolean } = {}
+): Promise<void> {
+  twitchAuth = next;
+  if (next) {
+    await saveToStorage(TWITCH_AUTH_STORAGE_KEY, next);
+  } else {
+    await removeFromStorage(TWITCH_AUTH_STORAGE_KEY);
+  }
+  await syncStateWithAuth({ keepDisplayName: options.keepDisplayName ?? Boolean(next), broadcast: options.broadcast });
+}
+async function refreshStoredProfile(): Promise<void> {
+  if (!twitchAuth) return;
+  const response = await helixFetch('/users');
+  if (!response.ok) {
+    throw new Error(`Failed to refresh Twitch profile (${response.status})`);
+  }
+  const body = (await response.json()) as { data?: Array<{ id: string; display_name: string; login: string }> };
+  const profile = body.data?.[0];
+  if (!profile) {
+    throw new Error('Missing Twitch user profile data');
+  }
+  if (
+    profile.display_name !== twitchAuth.displayName ||
+    profile.login !== twitchAuth.login ||
+    profile.id !== twitchAuth.broadcasterId
+  ) {
+    await setAuthData(
+      {
+        ...twitchAuth,
+        displayName: profile.display_name,
+        login: profile.login,
+        broadcasterId: profile.id
+      },
+      { keepDisplayName: true }
+    );
+  } else {
+    await syncStateWithAuth({ keepDisplayName: true });
+  }
+}
+
+async function handleExpiredToken(): Promise<void> {
+  updateDiagnostics({ lastError: 'Token expired', websocketConnected: false, sessionId: null, subscriptions: 0 });
+  await setAuthData(null, { keepDisplayName: true });
+  cleanupEventSub();
+}
+
+async function handleAuthFailure(reason: unknown): Promise<void> {
+  console.warn('[background] Twitch authentication failure', reason);
+  updateDiagnostics({ lastError: 'Authentication required', websocketConnected: false, sessionId: null, subscriptions: 0 });
+  await setAuthData(null, { keepDisplayName: true });
+  cleanupEventSub();
+}
+
+async function performOAuthFlow(): Promise<TwitchAuthData> {
+  ensureClientId();
+  const redirectUri = chrome.identity.getRedirectURL(TWITCH_REDIRECT_PATH);
+  const state = generateState();
+  const authUrl = new URL('https://id.twitch.tv/oauth2/authorize');
+  authUrl.searchParams.set('client_id', TWITCH_CLIENT_ID);
+  authUrl.searchParams.set('redirect_uri', redirectUri);
+  authUrl.searchParams.set('response_type', 'token');
+  authUrl.searchParams.set('scope', TWITCH_REQUIRED_SCOPES.join(' '));
+  authUrl.searchParams.set('state', state);
+  authUrl.searchParams.set('force_verify', 'true');
+
+  const redirectUrl = await new Promise<string>((resolve, reject) => {
+    try {
+      chrome.identity.launchWebAuthFlow({ url: authUrl.toString(), interactive: true }, (responseUrl) => {
+        if (chrome.runtime.lastError) {
+          reject(new AuthCancelledError(chrome.runtime.lastError.message));
+          return;
+        }
+        if (!responseUrl) {
+          reject(new AuthCancelledError());
+          return;
+        }
+        resolve(responseUrl);
+      });
+    } catch (error) {
+      reject(error);
+    }
+  });
+
+  const parsed = new URL(redirectUrl);
+  const fragment = parsed.hash.startsWith('#') ? parsed.hash.slice(1) : parsed.hash;
+  const params = new URLSearchParams(fragment);
+  const returnedState = params.get('state');
+  const accessToken = params.get('access_token');
+  const expiresInRaw = params.get('expires_in');
+  const scopeList = params.get('scope')?.split(' ').filter(Boolean) ?? [];
+
+  if (!accessToken) {
+    throw new Error('Missing access token from Twitch redirect');
+  }
+  if (returnedState !== state) {
+    throw new Error('OAuth state mismatch');
+  }
+
+  const missing = scopesMissing(TWITCH_REQUIRED_SCOPES, scopeList);
+  if (missing.length > 0) {
+    throw new MissingScopesError(missing);
+  }
+
+  const expiresIn = Number.parseInt(expiresInRaw ?? '0', 10);
+  const expiresAt = Date.now() + Math.max(expiresIn, 0) * 1000;
+  const profile = await fetchProfileWithToken(accessToken);
+
+  return {
+    accessToken,
+    expiresAt,
+    obtainedAt: Date.now(),
+    scopes: scopeList,
+    broadcasterId: profile.id,
+    displayName: profile.display_name,
+    login: profile.login
+  };
+}
+
+async function fetchProfileWithToken(token: string): Promise<{ id: string; display_name: string; login: string }> {
+  ensureClientId();
+  const response = await fetch(`${TWITCH_HELIX_BASE}/users`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Client-Id': TWITCH_CLIENT_ID
+    }
+  });
+  if (!response.ok) {
+    if (response.status === 401) {
+      throw new AuthCancelledError('Authorization rejected');
+    }
+    throw new Error(`Failed to fetch Twitch profile (${response.status})`);
+  }
+  const body = (await response.json()) as { data?: Array<{ id: string; display_name: string; login: string }> };
+  const profile = body.data?.[0];
+  if (!profile) {
+    throw new Error('Twitch profile payload missing');
+  }
+  return profile;
+}
+
+function ensureClientId(): void {
+  if (!TWITCH_CLIENT_ID) {
+    throw new MissingClientIdError();
+  }
+}
+
+function generateState(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+async function helixFetch(path: string, init: RequestInit = {}, attempt = 0): Promise<Response> {
+  if (!twitchAuth) {
+    throw new Error('Not authenticated with Twitch');
+  }
+  ensureClientId();
+  const headers = new Headers(init.headers ?? {});
+  headers.set('Authorization', `Bearer ${twitchAuth.accessToken}`);
+  headers.set('Client-Id', TWITCH_CLIENT_ID);
+  if (init.method === 'POST' || init.method === 'PATCH') {
+    headers.set('Content-Type', 'application/json');
+  }
+
+  const response = await fetch(`${TWITCH_HELIX_BASE}${path}`, { ...init, headers });
+  if (response.status === 401) {
+    await handleAuthFailure('Unauthorized');
+    return response;
+  }
+  if (response.status === 429 && attempt < 3) {
+    const reset = response.headers.get('Ratelimit-Reset');
+    const now = Date.now();
+    let delay = Math.pow(2, attempt) * 1000;
+    if (reset) {
+      const resetEpoch = Number.parseInt(reset, 10) * 1000;
+      if (!Number.isNaN(resetEpoch)) {
+        delay = Math.max(resetEpoch - now, delay);
+      }
+    }
+    await wait(delay);
+    return helixFetch(path, init, attempt + 1);
+  }
+  return response;
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+async function startEventSub(): Promise<void> {
+  if (!twitchAuth || !isAuthUsable(twitchAuth)) {
+    return;
+  }
+  cleanupEventSub();
+  connectEventSub();
+}
+
+function connectEventSub(url?: string): void {
+  if (!twitchAuth || !isAuthUsable(twitchAuth)) {
+    return;
+  }
+  const target = url ?? TWITCH_EVENTSUB_WS;
+  try {
+    const socket = new WebSocket(target);
+    eventSubSocket = socket;
+    updateDiagnostics({ websocketConnected: false, sessionId: null });
+
+    socket.addEventListener('open', () => {
+      updateDiagnostics({ websocketConnected: true, lastError: null });
+    });
+
+    socket.addEventListener('message', (event) => {
+      handleEventSubMessage(String(event.data ?? ''));
+    });
+
+    socket.addEventListener('close', (event) => {
+      console.info('[background] EventSub socket closed', event.code, event.reason);
+      eventSubSocket = null;
+      eventSubSessionId = null;
+      reconnectBackoffMs = Math.min(reconnectBackoffMs * 2, MAX_BACKOFF_MS);
+      clearKeepaliveTimer();
+      updateDiagnostics({ websocketConnected: false, sessionId: null, subscriptions: 0 });
+      scheduleReconnect('socket-close');
+    });
+
+    socket.addEventListener('error', (event) => {
+      console.warn('[background] EventSub socket error', event);
+      updateDiagnostics({ lastError: 'WebSocket error' });
+    });
+  } catch (error) {
+    console.error('[background] Failed to open EventSub socket', error);
+    scheduleReconnect('socket-error');
+  }
+}
+
+function clearKeepaliveTimer(): void {
+  if (keepaliveTimer) {
+    clearTimeout(keepaliveTimer);
+    keepaliveTimer = null;
+  }
+}
+
+function scheduleReconnect(reason: string): void {
+  if (!twitchAuth || !isAuthUsable(twitchAuth)) {
+    return;
+  }
+  if (eventSubReconnectTimer) {
+    return;
+  }
+  updateDiagnostics({ lastError: reason });
+  const delay = reconnectBackoffMs;
+  eventSubReconnectTimer = setTimeout(() => {
+    eventSubReconnectTimer = null;
+    connectEventSub();
+  }, delay);
+}
+
+function cleanupEventSub(): void {
+  if (eventSubReconnectTimer) {
+    clearTimeout(eventSubReconnectTimer);
+    eventSubReconnectTimer = null;
+  }
+  clearKeepaliveTimer();
+  if (eventSubSocket) {
+    try {
+      eventSubSocket.close();
+    } catch (error) {
+      console.warn('[background] Error closing EventSub socket', error);
+    }
+  }
+  eventSubSocket = null;
+  eventSubSessionId = null;
+  updateDiagnostics({ websocketConnected: false, sessionId: null, subscriptions: 0 });
+  reconnectBackoffMs = INITIAL_BACKOFF_MS;
+}
+
+function handleEventSubMessage(raw: string): void {
+  let parsed: any;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    console.warn('[background] Failed to parse EventSub message', error);
+    return;
+  }
+  const type: string | undefined = parsed?.metadata?.message_type;
+  switch (type) {
+    case 'session_welcome':
+      handleSessionWelcome(parsed?.payload);
+      break;
+    case 'session_keepalive':
+      recordKeepalive();
+      break;
+    case 'notification':
+      handleNotification(parsed?.payload);
+      break;
+    case 'session_reconnect':
+      handleSessionReconnect(parsed?.payload);
+      break;
+    case 'revocation':
+      handleRevocation(parsed?.payload);
+      break;
+    case 'session_close':
+      handleSessionClose(parsed?.payload);
+      break;
+    default:
+      console.debug('[background] Unhandled EventSub message type', type);
+      break;
+  }
+}
+
+function handleSessionWelcome(payload: any): void {
+  const session = payload?.session;
+  eventSubSessionId = session?.id ?? null;
+  reconnectBackoffMs = INITIAL_BACKOFF_MS;
+  keepaliveTimeoutMs = (session?.keepalive_timeout_seconds ?? 10) * 1000;
+  updateDiagnostics({ sessionId: eventSubSessionId, lastError: null });
+  recordKeepalive();
+  void ensureSubscriptions();
+}
+
+function recordKeepalive(): void {
+  clearKeepaliveTimer();
+  const now = Date.now();
+  updateDiagnostics({ lastKeepaliveAt: now });
+  if (keepaliveTimeoutMs > 0) {
+    keepaliveTimer = setTimeout(() => {
+      console.warn('[background] EventSub keepalive timeout');
+      updateDiagnostics({ lastError: 'Keepalive timeout', websocketConnected: false, sessionId: null });
+      cleanupEventSub();
+      scheduleReconnect('keepalive-timeout');
+    }, keepaliveTimeoutMs + 5_000);
+  }
+}
+
+function handleNotification(payload: any): void {
+  const subscriptionType: string = payload?.subscription?.type ?? 'unknown';
+  const bindingType = mapSubscriptionToBinding(subscriptionType);
+  updateDiagnostics({
+    lastNotificationAt: Date.now(),
+    lastNotificationType: subscriptionType
+  });
+  if (!bindingType) {
+    console.debug('[background] Ignoring unsupported subscription type', subscriptionType);
+    return;
+  }
+  routeEvent({
+    source: 'eventsub',
+    subscriptionType,
+    bindingType,
+    receivedAt: Date.now(),
+    payload: payload?.event
+  });
+}
+
+function handleSessionReconnect(payload: any): void {
+  const url: string | null = payload?.session?.reconnect_url ?? null;
+  console.info('[background] EventSub requested reconnect', url);
+  cleanupEventSub();
+  reconnectBackoffMs = INITIAL_BACKOFF_MS;
+  if (url) {
+    connectEventSub(url);
+  } else {
+    scheduleReconnect('session-reconnect');
+  }
+}
+
+function handleRevocation(payload: any): void {
+  const type: string = payload?.subscription?.type ?? 'unknown';
+  console.warn('[background] Subscription revoked', type, payload?.status);
+  updateDiagnostics({ lastError: `Revoked: ${type}` });
+  void ensureSubscriptions();
+}
+
+function handleSessionClose(payload: any): void {
+  const status = payload?.session?.status ?? 'unknown';
+  console.warn('[background] EventSub session closed', status);
+  updateDiagnostics({ lastError: `Session closed: ${status}`, websocketConnected: false, sessionId: null, subscriptions: 0 });
+  cleanupEventSub();
+  scheduleReconnect('session-close');
+}
+async function ensureSubscriptions(): Promise<void> {
+  if (!twitchAuth || !eventSubSessionId) {
+    return;
+  }
+  try {
+    const definitions = getRequiredEventSubDefinitions(twitchAuth.broadcasterId);
+    const existing = await listSubscriptions();
+    let active = 0;
+
+    for (const definition of definitions) {
+      const match = existing.find((entry) => subscriptionMatchesDefinition(entry, definition, eventSubSessionId));
+      if (match && match.status === 'enabled') {
+        active += 1;
+      } else {
+        await createSubscription(definition);
+        active += 1;
+      }
+
+      const stale = existing.filter(
+        (entry) =>
+          subscriptionMatchesDefinition(entry, definition) &&
+          entry.transport?.method === 'websocket' &&
+          entry.transport?.session_id &&
+          entry.transport.session_id !== eventSubSessionId
+      );
+      for (const entry of stale) {
+        await deleteSubscription(entry.id);
+      }
+    }
+
+    updateDiagnostics({ subscriptions: active, lastError: null });
+  } catch (error) {
+    console.error('[background] Failed to ensure EventSub subscriptions', error);
+    updateDiagnostics({ lastError: 'Subscription sync failed' });
+    scheduleReconnect('ensure-subscriptions');
+  }
+}
+
+async function listSubscriptions(): Promise<HelixSubscription[]> {
+  const response = await helixFetch('/eventsub/subscriptions');
+  if (!response.ok) {
+    throw new Error(`Failed to list EventSub subscriptions (${response.status})`);
+  }
+  const body = (await response.json()) as { data?: HelixSubscription[] };
+  return body.data ?? [];
+}
+
+async function createSubscription(definition: EventSubSubscriptionDefinition): Promise<void> {
+  if (!eventSubSessionId) {
+    return;
+  }
+  const response = await helixFetch('/eventsub/subscriptions', {
+    method: 'POST',
+    body: JSON.stringify({
+      type: definition.type,
+      version: definition.version,
+      condition: definition.condition,
+      transport: { method: 'websocket', session_id: eventSubSessionId }
+    })
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to create subscription (${response.status})`);
+  }
+}
+
+async function deleteSubscription(id: string): Promise<void> {
+  const response = await helixFetch(`/eventsub/subscriptions?id=${encodeURIComponent(id)}`, {
+    method: 'DELETE'
+  });
+  if (!response.ok && response.status !== 404) {
+    throw new Error(`Failed to delete subscription (${response.status})`);
+  }
+}
+
+async function deleteAllSubscriptions(): Promise<void> {
+  if (!twitchAuth) {
+    return;
+  }
+  try {
+    const subs = await listSubscriptions();
+    for (const sub of subs) {
+      if (subscriptionOwnedByBroadcaster(sub, twitchAuth.broadcasterId)) {
+        await deleteSubscription(sub.id);
+      }
+    }
+  } catch (error) {
+    console.warn('[background] Failed to clean subscriptions', error);
+  }
+}
+
+function subscriptionMatchesDefinition(
+  entry: HelixSubscription,
+  definition: EventSubSubscriptionDefinition,
+  sessionId?: string | null
+): boolean {
+  if (entry.type !== definition.type || entry.version !== definition.version) {
+    return false;
+  }
+  const requiredEntries = Object.entries(definition.condition);
+  for (const [key, value] of requiredEntries) {
+    if (entry.condition?.[key] !== value) {
+      return false;
+    }
+  }
+  if (sessionId) {
+    return entry.transport?.session_id === sessionId;
+  }
+  return true;
+}
+
+function subscriptionOwnedByBroadcaster(sub: HelixSubscription, broadcasterId: string): boolean {
+  const conditionValues = Object.values(sub.condition ?? {});
+  return conditionValues.includes(broadcasterId);
+}
+
+function mapSubscriptionToBinding(type: string): BindingEventType | null {
+  switch (type) {
+    case 'channel.channel_points_custom_reward_redemption.add':
+      return 'channel_points';
+    case 'channel.cheer':
+      return 'bits';
+    case 'channel.subscribe':
+      return 'sub';
+    case 'channel.follow':
+      return 'follow';
+    default:
+      return null;
+  }
+}
+const TEST_EVENT_SUBSCRIPTION_MAP: Record<TestEventType, string> = {
+  channel_points: 'channel.channel_points_custom_reward_redemption.add',
+  bits: 'channel.cheer',
+  gift_sub: 'channel.subscribe',
+  sub: 'channel.subscribe',
+  follow: 'channel.follow'
+};
+
+function routeEvent(event: RoutedEvent): void {
+  updateDiagnostics({ lastNotificationAt: event.receivedAt, lastNotificationType: event.subscriptionType });
+  if (!cachedState.captureEvents) {
+    console.info('[background] Capture disabled; ignoring event', event.subscriptionType);
+    return;
+  }
+  console.info('[background] Routed event', event.subscriptionType, event.payload);
+  // Phase 4 will map events to bindings; for now this is a placeholder.
+}
+
+async function handleTestEvent(payload: {
+  type: TestEventType;
+  username: string;
+  amount: number | null;
+  rewardId: string | null;
+  subTier: SubTier;
+}): Promise<'processed' | 'ignored'> {
+  const subscriptionType = TEST_EVENT_SUBSCRIPTION_MAP[payload.type];
+  routeEvent({
+    source: 'test',
+    subscriptionType,
+    bindingType: payload.type,
+    receivedAt: Date.now(),
+    payload
+  });
+  return cachedState.captureEvents ? 'processed' : 'ignored';
+}
+
+async function ensureFreshAuth(): Promise<boolean> {
+  if (!twitchAuth) return false;
+  if (!isAuthUsable(twitchAuth)) {
+    await handleExpiredToken();
+    return false;
+  }
+  return true;
+}
+type ActionResult = {
+  status: 'ok' | 'error';
+  messageKey?: string;
+  messageParams?: Record<string, string | number>;
+};
+
+async function initiateConnect(): Promise<ActionResult> {
+  try {
+    const auth = await performOAuthFlow();
+    await setAuthData(auth, { keepDisplayName: true });
+    await startEventSub();
+    return { status: 'ok', messageKey: 'toasts.twitchConnected' };
+  } catch (error) {
+    if (error instanceof AuthCancelledError) {
+      return { status: 'error', messageKey: 'toasts.twitchAuthCancelled' };
+    }
+    if (error instanceof MissingClientIdError) {
+      return { status: 'error', messageKey: 'toasts.twitchMissingClientId' };
+    }
+    if (error instanceof MissingScopesError) {
+      return {
+        status: 'error',
+        messageKey: 'toasts.twitchMissingScopes',
+        messageParams: { scopes: error.missing.join(', ') }
+      };
+    }
+    console.error('[background] Twitch connect failed', error);
+    return { status: 'error', messageKey: 'toasts.twitchAuthFailed' };
+  }
+}
+
+async function initiateReconnect(): Promise<ActionResult> {
+  if (!(await ensureFreshAuth())) {
+    return await initiateConnect();
+  }
+  await startEventSub();
+  return { status: 'ok', messageKey: 'toasts.twitchReconnected' };
+}
+
+async function disconnectFromTwitch(): Promise<ActionResult> {
+  if (twitchAuth) {
+    await deleteAllSubscriptions();
+  }
+  cleanupEventSub();
+  await setAuthData(null, { keepDisplayName: false });
+  updateDiagnostics({ lastError: null, subscriptions: 0, sessionId: null, websocketConnected: false });
+  return { status: 'ok', messageKey: 'toasts.twitchDisconnected' };
+}
+
+function respondToPopup(sendResponse: (response?: BackgroundToPopupMessage) => void, message: BackgroundToPopupMessage): void {
   sendResponse(message);
+}
+
+function sendActionResponse(
+  sendResponse: (response?: BackgroundToPopupMessage) => void,
+  result: ActionResult
+): void {
+  respondToPopup(sendResponse, {
+    type: 'BACKGROUND_ACTION_RESULT',
+    status: result.status,
+    messageKey: result.messageKey,
+    messageParams: result.messageParams,
+    state: cachedState
+  });
+}
+async function acceptPopupState(nextState: PopupPersistentState): Promise<void> {
+  cachedState = {
+    ...nextState,
+    loggedIn: cachedState.loggedIn,
+    twitchDisplayName: cachedState.twitchDisplayName
+  };
+  await persistCachedState();
 }
 
 async function handlePopupMessage(
@@ -34,18 +807,41 @@ async function handlePopupMessage(
     case 'POPUP_READY':
     case 'POPUP_REQUEST_STATE': {
       respondToPopup(sendResponse, { type: 'BACKGROUND_STATE', state: cachedState });
+      pushDiagnostics();
       return;
     }
     case 'POPUP_UPDATE_STATE': {
-      cachedState = message.state;
-      await saveToStorage(POPUP_STATE_STORAGE_KEY, cachedState);
+      await acceptPopupState(message.state);
       respondToPopup(sendResponse, { type: 'BACKGROUND_STATE', state: cachedState });
       return;
     }
     case 'POPUP_TOGGLE_DEVTOOLS': {
-      cachedState = { ...cachedState, diagnosticsExpanded: message.expanded };
-      await saveToStorage(POPUP_STATE_STORAGE_KEY, cachedState);
+      await updateCachedState({ diagnosticsExpanded: message.expanded });
       respondToPopup(sendResponse, { type: 'BACKGROUND_DEVTOOLS', expanded: message.expanded });
+      return;
+    }
+    case 'POPUP_TWITCH_CONNECT': {
+      const result = await initiateConnect();
+      sendActionResponse(sendResponse, result);
+      return;
+    }
+    case 'POPUP_TWITCH_RECONNECT': {
+      const result = await initiateReconnect();
+      sendActionResponse(sendResponse, result);
+      return;
+    }
+    case 'POPUP_TWITCH_DISCONNECT': {
+      const result = await disconnectFromTwitch();
+      sendActionResponse(sendResponse, result);
+      return;
+    }
+    case 'POPUP_TRIGGER_TEST_EVENT': {
+      const status = await handleTestEvent(message.payload);
+      const result: ActionResult =
+        status === 'processed'
+          ? { status: 'ok', messageKey: 'toasts.testFired' }
+          : { status: 'error', messageKey: 'toasts.captureDisabled' };
+      sendActionResponse(sendResponse, result);
       return;
     }
     default:

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -113,10 +113,31 @@
     "connectHint": "Connect to manage bindings"
   },
   "toasts": {
-    "testFired": "Test payload logged to console.",
+    "testFired": "Test event sent.",
     "bindingSaved": "Binding saved.",
     "bindingDeleted": "Binding deleted.",
-    "testInvalid": "Fill out the required test event fields."
+    "testInvalid": "Fill out the required test event fields.",
+    "captureDisabled": "Enable event capture to process events.",
+    "twitchConnected": "Connected to Twitch.",
+    "twitchReconnected": "Twitch session refreshed.",
+    "twitchDisconnected": "Disconnected from Twitch.",
+    "twitchAuthFailed": "Could not authenticate with Twitch. Try again.",
+    "twitchMissingScopes": "Grant the required scopes: {scopes}.",
+    "twitchMissingClientId": "Set TWITCH_CLIENT_ID before building the extension.",
+    "twitchAuthCancelled": "Twitch sign-in was cancelled."
+  },
+  "diagnostics": {
+    "wsConnected": "WS connected",
+    "sessionId": "Session",
+    "subscriptions": "Subscriptions",
+    "lastKeepalive": "Last keepalive",
+    "lastNotification": "Last notification",
+    "lastNotificationType": "Last type",
+    "lastError": "Last error",
+    "yes": "Yes",
+    "no": "No",
+    "unknown": "—",
+    "none": "None"
   },
   "misc": {
     "language": "Language"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -75,6 +75,8 @@
     "empty": "No bindings yet.",
     "toggleLabel": "Enabled",
     "delete": "Delete",
+    "deleteConfirm": "Confirm?",
+    "toggleAria": "Enable or disable {label}",
     "unsavedConfirm": "Leave without saving?",
     "unsavedConfirmLeave": "Leave",
     "unsavedConfirmCancel": "Cancel",

--- a/src/locales/pseudo.json
+++ b/src/locales/pseudo.json
@@ -113,10 +113,31 @@
     "connectHint": "Ćōņņēćŧ ŧō māņàĝē ƅīņđīņĝś"
   },
   "toasts": {
-    "testFired": "Ŧēśŧ ƥàẏļōàđ ļōĝĝēđ ŧō ćōņśōļē.",
+    "testFired": "Ŧēśŧ ēṽēņŧ śēņŧ.",
     "bindingSaved": "Ɓīņđīņĝ śàṽēđ.",
     "bindingDeleted": "Ɓīņđīņĝ đēļēŧēđ.",
-    "testInvalid": "Ƒīļļ īņ ŧĥē ŕēɋŭīŕēđ ŧēśŧ ēṽēņŧ ƒīēļđś."
+    "testInvalid": "Ƒīļļ īņ ŧĥē ŕēɋŭīŕēđ ŧēśŧ ēṽēņŧ ƒīēļđś.",
+    "captureDisabled": "Ȅņàƅļē ēṽēņŧ ćàƥŧŭŕē ŧō ƥŕōċēşş ēṽēņŧś.",
+    "twitchConnected": "Ćōņņēćŧēđ ŧō Ŧŵīŧćĥ.",
+    "twitchReconnected": "Ŧŵīŧćĥ śēśśīōņ ŕēƒŕēşĥēđ.",
+    "twitchDisconnected": "Ḓīśċōņņēćŧēđ ƒŕōṁ Ŧŵīŧćĥ.",
+    "twitchAuthFailed": "Ćōŭļđ ņōŧ àŭŧĥēņŧīċàŧē ŵīŧĥ Ŧŵīŧćĥ. Ŧŕŷ àĝàīņ.",
+    "twitchMissingScopes": "Ɠŕàņŧ ŧĥē ŕēɋŭīŕēđ śċōƥēś: {scopes}.",
+    "twitchMissingClientId": "Ŝēŧ ŦŴȈŦĆĤ_ĆĿĮȄȦŇŦ_ȈḒ ƅēƒōŕē ƅŭīļđīņĝ ŧĥē ēẋŧēņśīōņ.",
+    "twitchAuthCancelled": "Ŧŵīŧćĥ śīĝņ-īņ ŵàś ćàņċēļļēđ."
+  },
+  "diagnostics": {
+    "wsConnected": "ŴŜ ćōņņēćŧēđ",
+    "sessionId": "Ŝēśśīōņ",
+    "subscriptions": "Ŝŭƅśċŕīƥŧīōņś",
+    "lastKeepalive": "Ŀàśŧ ķēēƥàļīṽē",
+    "lastNotification": "Ŀàśŧ ņōŧīƒīċàŧīōņ",
+    "lastNotificationType": "Ŀàśŧ ŧŷƥē",
+    "lastError": "Ŀàśŧ ēŕŕōŕ",
+    "yes": "Ɏēś",
+    "no": "Ƞō",
+    "unknown": "—",
+    "none": "Ƞōņē"
   },
   "misc": {
     "language": "Ļàņĝŭàĝē"

--- a/src/locales/pseudo.json
+++ b/src/locales/pseudo.json
@@ -75,6 +75,8 @@
     "empty": "Ňō ƅīņđīņĝś ẏēŧ.",
     "toggleLabel": "Ĕņàƅļēđ",
     "delete": "Đēļēŧē",
+    "deleteConfirm": "Ćōņƒīŕṁ?",
+    "toggleAria": "Ĕņàƅļē ōŗ đīśàƅļē {label}",
     "unsavedConfirm": "Ľēàṽē ŵīŧĥōŭŧ śàṽīņĝ?",
     "unsavedConfirmLeave": "Ľēàṽē",
     "unsavedConfirmCancel": "Ćàņćēļ",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,6 +6,7 @@
   "minimum_chrome_version": "116",
   "default_locale": "en",
   "permissions": ["identity", "storage", "scripting", "activeTab"],
+  "host_permissions": ["https://id.twitch.tv/*", "https://api.twitch.tv/*"],
   "background": {
     "service_worker": "background.js",
     "type": "module"

--- a/src/popup/styles/main.css
+++ b/src/popup/styles/main.css
@@ -663,17 +663,30 @@ input[type='range'] {
   overflow: hidden;
   transition: max-height 0.2s ease;
   background: rgba(255, 255, 255, 0.04);
+  padding: 0 12px;
 }
 
 .diagnostics--open .diagnostics__body {
-  max-height: 200px;
+  max-height: 220px;
+  padding-bottom: 12px;
 }
 
-.diagnostics__body pre {
+.diagnostics__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px 12px;
   margin: 0;
-  padding: 12px;
+  padding: 12px 0 0;
   font-size: 11px;
-  white-space: pre-wrap;
+}
+
+.diagnostics__grid dt {
+  font-weight: 600;
+}
+
+.diagnostics__grid dd {
+  margin: 0;
+  word-break: break-word;
 }
 
 .toast-container {

--- a/src/popup/styles/main.css
+++ b/src/popup/styles/main.css
@@ -44,6 +44,18 @@ textarea:focus-visible {
   outline-offset: 2px;
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 #app {
   padding: 16px;
   box-sizing: border-box;
@@ -535,24 +547,62 @@ input[type='range'] {
 }
 
 .binding-row {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
   padding: 12px;
   border-radius: var(--border-radius);
   border: 1px solid var(--panel-border);
   margin-bottom: 8px;
   gap: 12px;
+  transition: background-color 0.2s ease;
 }
 
-.binding-row__actions {
+.binding-row--hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.binding-row__toggle {
   display: flex;
   align-items: center;
-  gap: 8px;
+  justify-content: center;
+}
+
+.binding-row__main {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  background: transparent;
+  border: none;
+  padding: 8px 12px;
+  border-radius: var(--border-radius);
+  text-align: left;
+  cursor: pointer;
+}
+
+.binding-row__label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .binding-row__chevron {
   font-size: 18px;
+}
+
+.binding-row__delete {
+  white-space: nowrap;
+}
+
+.binding-row__delete--confirm {
+  color: var(--status-disconnected);
+}
+
+.binding-row__delete--confirm:hover {
+  background: rgba(248, 81, 73, 0.18);
 }
 
 .empty {

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -1,14 +1,36 @@
-import type { PopupPersistentState } from './state';
+import type { PopupPersistentState, SubTier, TestEventType } from './state';
+import type { TwitchDiagnosticsSnapshot } from './twitch';
 
 export type PopupToBackgroundMessage =
   | { type: 'POPUP_READY' }
   | { type: 'POPUP_UPDATE_STATE'; state: PopupPersistentState }
   | { type: 'POPUP_REQUEST_STATE' }
-  | { type: 'POPUP_TOGGLE_DEVTOOLS'; expanded: boolean };
+  | { type: 'POPUP_TOGGLE_DEVTOOLS'; expanded: boolean }
+  | { type: 'POPUP_TWITCH_CONNECT' }
+  | { type: 'POPUP_TWITCH_RECONNECT' }
+  | { type: 'POPUP_TWITCH_DISCONNECT' }
+  | {
+      type: 'POPUP_TRIGGER_TEST_EVENT';
+      payload: {
+        type: TestEventType;
+        username: string;
+        amount: number | null;
+        rewardId: string | null;
+        subTier: SubTier;
+      };
+    };
 
 export type BackgroundToPopupMessage =
   | { type: 'BACKGROUND_STATE'; state: PopupPersistentState }
-  | { type: 'BACKGROUND_DEVTOOLS'; expanded: boolean };
+  | { type: 'BACKGROUND_DEVTOOLS'; expanded: boolean }
+  | {
+      type: 'BACKGROUND_ACTION_RESULT';
+      status: 'ok' | 'error';
+      messageKey?: string;
+      messageParams?: Record<string, string | number>;
+      state?: PopupPersistentState;
+    }
+  | { type: 'BACKGROUND_DIAGNOSTICS'; diagnostics: TwitchDiagnosticsSnapshot };
 
 export type BackgroundToContentMessage =
   | {

--- a/src/shared/twitch.ts
+++ b/src/shared/twitch.ts
@@ -1,0 +1,89 @@
+export const TWITCH_CLIENT_ID = (process.env.TWITCH_CLIENT_ID ?? '').trim();
+
+export const TWITCH_REDIRECT_PATH = (process.env.TWITCH_REDIRECT_PATH ?? 'twitch').trim();
+
+export const TWITCH_REQUIRED_SCOPES = [
+  'channel:read:redemptions',
+  'bits:read',
+  'channel:read:subscriptions'
+] as const;
+
+export type TwitchScope = (typeof TWITCH_REQUIRED_SCOPES)[number];
+
+export const TWITCH_AUTH_BASE = 'https://id.twitch.tv/oauth2';
+export const TWITCH_HELIX_BASE = 'https://api.twitch.tv/helix';
+export const TWITCH_EVENTSUB_WS = 'wss://eventsub.wss.twitch.tv/ws';
+
+export interface TwitchAuthData {
+  accessToken: string;
+  expiresAt: number;
+  obtainedAt: number;
+  scopes: string[];
+  broadcasterId: string;
+  displayName: string;
+  login: string;
+}
+
+export const TWITCH_AUTH_STORAGE_KEY = 'twitchAuth';
+
+export interface TwitchDiagnosticsSnapshot {
+  websocketConnected: boolean;
+  sessionId: string | null;
+  subscriptions: number;
+  lastKeepaliveAt: number | null;
+  lastNotificationAt: number | null;
+  lastNotificationType: string | null;
+  lastError: string | null;
+}
+
+export function createEmptyDiagnostics(): TwitchDiagnosticsSnapshot {
+  return {
+    websocketConnected: false,
+    sessionId: null,
+    subscriptions: 0,
+    lastKeepaliveAt: null,
+    lastNotificationAt: null,
+    lastNotificationType: null,
+    lastError: null
+  };
+}
+
+export interface EventSubSubscriptionDefinition {
+  type: string;
+  version: string;
+  condition: Record<string, string>;
+}
+
+export function getRequiredEventSubDefinitions(broadcasterId: string): EventSubSubscriptionDefinition[] {
+  return [
+    {
+      type: 'channel.channel_points_custom_reward_redemption.add',
+      version: '1',
+      condition: { broadcaster_user_id: broadcasterId }
+    },
+    {
+      type: 'channel.cheer',
+      version: '1',
+      condition: { broadcaster_user_id: broadcasterId }
+    },
+    {
+      type: 'channel.subscribe',
+      version: '1',
+      condition: { broadcaster_user_id: broadcasterId }
+    },
+    {
+      type: 'channel.follow',
+      version: '2',
+      condition: {
+        broadcaster_user_id: broadcasterId,
+        moderator_user_id: broadcasterId
+      }
+    }
+  ];
+}
+
+export function scopesMissing(required: readonly string[], granted: string[]): string[] {
+  const grantedLower = new Set(granted.map((scope) => scope.toLowerCase()));
+  return required.filter((scope) => !grantedLower.has(scope.toLowerCase()));
+}
+


### PR DESCRIPTION
## Summary
- add a Twitch OAuth flow that stores broadcaster identity, scopes, and tokens for reuse
- implement a resilient EventSub WebSocket client with Helix subscription management and diagnostics updates
- connect the popup UI to the new background actions, extend localization/build config, and surface real routing feedback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e31ad433e4832c8d2e3f6ab1d667f1