### PR TITLE
Scope per-tab audio state and stabilize EventSub effects

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -14,29 +14,40 @@ async function clean() {
   await fs.mkdir(outDir, { recursive: true });
 }
 
+const baseBuildOptions = {
+  outdir: outDir,
+  bundle: true,
+  minify: false,
+  sourcemap: true,
+  target: ['chrome116'],
+  logLevel: 'info',
+  loader: {
+    '.json': 'json',
+    '.wasm': 'binary'
+  },
+  define: {
+    'process.env.TWITCH_CLIENT_ID': JSON.stringify(process.env.TWITCH_CLIENT_ID ?? ''),
+    'process.env.TWITCH_REDIRECT_PATH': JSON.stringify(process.env.TWITCH_REDIRECT_PATH ?? 'twitch')
+  }
+};
+
 async function bundle() {
   await build({
+    ...baseBuildOptions,
     entryPoints: {
       'background': path.join(srcDir, 'background/index.ts'),
-      'content': path.join(srcDir, 'content/index.ts'),
       'content/audio-worklet': path.join(srcDir, 'content/audio/worklet.ts'),
       'popup/index': path.join(srcDir, 'popup/index.ts')
     },
-    outdir: outDir,
-    bundle: true,
-    minify: false,
-    sourcemap: true,
-    target: ['chrome116'],
-    format: 'esm',
-    logLevel: 'info',
-    loader: {
-      '.json': 'json',
-      '.wasm': 'binary'
+    format: 'esm'
+  });
+
+  await build({
+    ...baseBuildOptions,
+    entryPoints: {
+      'content': path.join(srcDir, 'content/index.ts')
     },
-    define: {
-      'process.env.TWITCH_CLIENT_ID': JSON.stringify(process.env.TWITCH_CLIENT_ID ?? ''),
-      'process.env.TWITCH_REDIRECT_PATH': JSON.stringify(process.env.TWITCH_REDIRECT_PATH ?? 'twitch')
-    }
+    format: 'iife'
   });
 }
 

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -1,4 +1,4 @@
-import type { PopupPersistentState, SubTier, TestEventType } from './state';
+import type { MediaAvailabilityState, PopupPersistentState, SubTier, TestEventType } from './state';
 import type { TwitchDiagnosticsSnapshot } from './twitch';
 
 export type PopupToBackgroundMessage =
@@ -70,6 +70,10 @@ export type ContentToBackgroundMessage =
   | {
       type: 'AUDIO_EFFECTS_UPDATE';
       payload: { semitoneOffset: number; speedPercent: number };
+    }
+  | {
+      type: 'CONTENT_MEDIA_AVAILABILITY';
+      payload: { tabId: number | null; availability: MediaAvailabilityState };
     };
 
 export type PopupToContentMessage =

--- a/src/shared/state.ts
+++ b/src/shared/state.ts
@@ -94,10 +94,13 @@ export interface PopupPersistentState {
   diagnosticsExpanded: boolean;
   eventLogExpanded: boolean;
   mediaAvailability: MediaAvailabilityState;
+  activeTabId: number | null;
 }
 
 export const POPUP_STATE_STORAGE_KEY = 'popupState';
 export const MEDIA_AVAILABILITY_STORAGE_KEY = 'mediaAvailability';
+export const MEDIA_AVAILABILITY_BY_TAB_STORAGE_KEY = 'mediaAvailabilityByTab';
+export const MANUAL_AUDIO_STATE_STORAGE_KEY = 'manualAudioStateByTab';
 
 export type MediaAvailabilityReason = 'none' | 'no_media' | 'drm_cors';
 
@@ -106,6 +109,11 @@ export interface MediaAvailabilityState {
   hasUsableMedia: boolean;
   reason: MediaAvailabilityReason;
   tabId?: number | null;
+}
+
+export interface ManualAudioState {
+  semitoneOffset: number;
+  speedPercent: number;
 }
 
 export function createDefaultPopupState(): PopupPersistentState {
@@ -133,6 +141,7 @@ export function createDefaultPopupState(): PopupPersistentState {
       hasAnyMedia: true,
       hasUsableMedia: true,
       reason: 'none'
-    }
+    },
+    activeTabId: null
   };
 }


### PR DESCRIPTION
## Summary
- maintain manual audio baselines and media availability per tab so popup controls and availability messaging track the active tab while Twitch-driven effects fan out to every playable tab
- keep EventSub reconnects from cancelling active effects, replay the overlay to tabs when they become usable, and let resets clear the global Twitch adjustments in addition to the current tab's manual value
- allow content scripts to report availability via runtime messaging and sync the popup to the current tab on activation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e31ad433e4832c8d2e3f6ab1d667f1